### PR TITLE
Adding two options for more flexibility Silent & Folder Depth

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Options
   --source string[]      Source repositories to fetch commits
   --destination string   Destination repository to sync contributions into
   --days number          Specify the number of days back to include
+  --folder-depth         Specify the number of subfolders to look for repos in source
   --dry-run              Will execute script without syncing
   --force                Force push to the destination (implicit with reset)
   --reset                Reset the destination repository

--- a/README.md
+++ b/README.md
@@ -53,5 +53,6 @@ Options
   --dry-run              Will execute script without syncing
   --force                Force push to the destination (implicit with reset)
   --reset                Reset the destination repository
+  --silent               Will not prompt
   -h, --help
 ```

--- a/index.js
+++ b/index.js
@@ -22,6 +22,12 @@ const optionDefinitions = [
     defaultValue: 999999,
   },
   {
+    name: 'folder-depth',
+    type: Number,
+    description: 'Specify the level of subfolders to look for repos (default: 1)',
+    defaulValue: 1,
+  },
+  {
     name: 'dry-run',
     type: Boolean,
     description: 'Will execute script without syncing',
@@ -78,7 +84,7 @@ if (!options['dry-run'] && options.reset) {
   }
 }
 
-const { stdout } = exec(`cd ${options.source} && git standup -d ${options.days} -D iso-strict`);
+const { stdout } = exec(`cd ${options.source} && git standup -d ${options.days} -m${options['folder-depth']} -D iso-strict`);
 
 const commits = stdout
   .split('\n')


### PR DESCRIPTION
Added two options for flexibility: 
 * Silent: This allows users to create cron jobs 
 * FolderDepth: Passes the option onto git standup so that multiple subfolder levels can be included. 

Both of these items were added based on my own usage of the product. 
